### PR TITLE
Drop subunit and dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 3.5
     - pypy
 install:
-    - pip install -U setuptools==28.0.0
+    - pip install -U setuptools==33.1.1
     - python bootstrap.py
     - bin/buildout -n
 script:

--- a/ztk-versions.cfg
+++ b/ztk-versions.cfg
@@ -30,7 +30,7 @@ zope.formlib = 4.3.0
 zope.hookable = 4.0.4
 zope.i18n = 4.1.0
 zope.i18nmessageid = 4.0.3
-zope.index = 4.2.0
+zope.index = 4.3.0
 zope.interface = 4.3.2
 zope.intid = 4.1.0
 zope.keyreference = 4.1.0
@@ -60,18 +60,23 @@ zope.structuredtext = 4.1.0
 zope.tal = 4.2.0
 zope.tales = 4.1.1
 zope.testing = 4.5.0
-zope.testrunner = 4.5.1
+zope.testrunner = 4.7.0
 zope.traversing = 4.1.0
 zope.viewlet = 4.0.0
 
 # Direct dependencies
-BTrees = 4.3.1
+BTrees = 4.4.1
 persistent = 4.2.1
 python-gettext = 3.0
 pytz = 2016.6.1
-setuptools = 28.0.0
+setuptools = 33.1.1
 six = 1.10.0
 transaction = 2.0.3
+
+# zope.password needs these
+bcrypt = 3.1.3
+cffi = 1.10.0
+pycparser = 2.17
 
 # Python2-only
 zope.untrustedpython = 4.0.0

--- a/ztk-versions.cfg
+++ b/ztk-versions.cfg
@@ -72,17 +72,6 @@ pytz = 2016.6.1
 setuptools = 28.0.0
 six = 1.10.0
 transaction = 2.0.3
-python-subunit = 1.2.0
-# Required by python-subunit.  Drop these when zope.testrunner drops subunit.
-argparse = 1.4.0
-extras = 1.0.0
-fixtures = 3.0.0
-linecache2 = 1.0.0
-pbr = 1.10.0
-python-mimeparse = 1.5.3
-testtools = 2.2.0
-traceback2 = 1.4.0
-unittest2 = 1.1.0
 
 # Python2-only
 zope.untrustedpython = 4.0.0


### PR DESCRIPTION
zope.testrunner is [dropping the feature](https://github.com/zopefoundation/zope.testrunner/pull/53), so we don't need to test with it.