### PR TITLE
Declare Python 3.12 support in document.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ You should follow these in most cases.
 Python versions
 ---------------
 
-The ZTK supports CPython 3.7, 3.8, 3.9, 3.10, 3.11, and PyPy3.
+The ZTK supports CPython 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and PyPy3.
 
 
 Documentation


### PR DESCRIPTION
Python 3.12 support is added in https://github.com/zopefoundation/zopetoolkit/pull/74