### PR TITLE
Replace EndBug/add-and-commit with plain git commands

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           vereqsyn ztk-versions.cfg dependabot/requirements.txt
       - name: Commit changes
-        uses: EndBug/add-and-commit@v10
-        with:
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
-          message: Version synchronization
-          add: '["ztk-versions.cfg", "dependabot/requirements.txt"]'
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add ztk-versions.cfg dependabot/requirements.txt
+          git diff --cached --quiet || git commit -m "Version synchronization"
+          git push


### PR DESCRIPTION
Replace the `EndBug/add-and-commit` action which is no longer allowed to be used with plain git commands.

Ported from https://github.com/zopefoundation/groktoolkit/pull/165.